### PR TITLE
Support multiple requests + working find peer test

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -5,7 +5,7 @@ var test = require('tape')
 // TODO: Improve reliability by not using live network
 
 test('Find nodes (Pride & Prejudice)', function (t) {
-  t.plan(1)
+  t.plan(2)
 
   var hash = '1E69917FBAA2C767BCA463A96B5572785C6D8A12' // Pride & Prejudice
   var dht = new DHT(new Buffer(hash, 'hex'))
@@ -13,13 +13,12 @@ test('Find nodes (Pride & Prejudice)', function (t) {
 
   dht.on('node', once(function (peer) {
     t.pass('Found at least one other DHT node')
-    dht.close()
   }))
 
-  // TODO
-  // dht.on('peer', once(function (peer) {
-  //   t.pass('Found at least one peer that has the file')
-  // }))
+  dht.on('peer', once(function (peer) {
+    t.pass('Found at least one peer that has the file')
+    dht.close()
+  }))
 
   // 10 minute timeout
   var timeout = setTimeout(function () {


### PR DESCRIPTION
Hey there

I saw your talk at RealtimeConf and got inspired to try and help out with Webtorrent. 

This PR adds support for resending a request to a node if a previous request to the same node hasn't generated a response after `REQ_TIMEOUT` ms. 

By adding this functionality, the find peers test consistently passes.

Let me know if this helps!

Bob
