### PR TITLE
Ensure 0 < port < 65535

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ DHT.prototype.query = function (addr) {
 
   var host = addr.split(':')[0]
   var port = Number(addr.split(':')[1])
+  if (!(port > 0 && port < 65535)) return;
   this.socket.send(this.message, 0, this.message.length, port, host, function () {
     setTimeout(function () {
       this.reqs[addr] = (this.reqs[addr] || 0) + 1


### PR DESCRIPTION
This PR makes sure we only connect to a node if the port range is between `1-65536`.
We need to do this since bad nodes in the dht sometimes send invalid ports.
