### PR TITLE
Fix bug: Trying to convert undefined to string

### DIFF
--- a/client.js
+++ b/client.js
@@ -529,7 +529,11 @@ DHT.prototype._onData = function (data, rinfo) {
 
   // debug('got message from ' + addr + ' ' + JSON.stringify(message))
 
-  var type = message.y.toString()
+  var type;
+  
+  if (message.y) {
+    type = message.y.toString()
+  }
 
   if (type === MESSAGE_TYPE.QUERY) {
     self._onQuery(addr, message)


### PR DESCRIPTION
Fix bug when trying to convert malformed message.y (undefined) to string.

```
/Users/alexander/trrnts/node_modules/bittorrent-dht/client.js:533
  var type = message.y.toString()
                       ^
TypeError: Cannot call method 'toString' of undefined
    at DHT._onData (/Users/alexander/trrnts/node_modules/bittorrent-dht/client.js:533:24)
    at Socket.EventEmitter.emit (events.js:98:17)
    at UDP.onMessage (dgram.js:440:8)
```
