### PR TITLE
Add IPv6 DHT support

### DIFF
--- a/client.js
+++ b/client.js
@@ -84,7 +84,7 @@ DHT.prototype.addNode = function (node) {
   if (node.id) {
     node.id = toBuffer(node.id)
     var old = !!this._rpc.nodes.get(node.id)
-    this._rpc.nodes.add(node)
+    this._rpc.addNode(node)
     if (!old) this.emit('node', node)
     return
   }
@@ -362,9 +362,9 @@ DHT.prototype._decodePeers = function (buf) {
     var port = buf[i].readUInt16BE(this.ipv6 ? 16 : 4)
     if (!port) continue
     peers.push({
-                 host: this._rpc._parseIP(buf[i], 0, this.ipv6),
-                 port: port
-               })
+      host: this._rpc._parseIP(buf[i], 0, this.ipv6),
+      port: port
+    })
   }
 
   return peers

--- a/client.js
+++ b/client.js
@@ -353,22 +353,18 @@ DHT.prototype._decodePeers = function (buf) {
   // According to BEP-0032, we need to be able to handle 'hybrid' values
   // lists (lists that contain both IPv4 and IPV6 addresses). However, since they're
   // not supposed to be sent, we just ignore items of the wrong type
-  try {
-    for (var i = 0; i < buf.length; i++) {
-      var size = this.ipv6 ? 18 : 6
-      if (buf[i].length !== size) {
-        this._debug("Received invalid peer with length %s (presumably an %s peer) when we're using %s. Skipping", buf[i].length, this.ipv6 ? 'IPv4' : 'IPv6', this.ipv6 ? 'IPv6' : 'IPv4')
-        continue
-      }
-      var port = buf[i].readUInt16BE(this.ipv6 ? 16 : 4)
-      if (!port) continue
-      peers.push({
-        host: this._rpc._parseIP(buf[i], 0),
-        port: port
-      })
+  for (var i = 0; i < buf.length; i++) {
+    var size = this.ipv6 ? 18 : 6
+    if (buf[i].length !== size) {
+      this._debug("Received invalid peer with length %s (presumably an %s peer) when we're using %s. Skipping", buf[i].length, this.ipv6 ? 'IPv4' : 'IPv6', this.ipv6 ? 'IPv6' : 'IPv4')
+      continue
     }
-  } catch (err) {
-    // do nothing
+    var port = buf[i].readUInt16BE(this.ipv6 ? 16 : 4)
+    if (!port) continue
+    peers.push({
+                 host: this._rpc._parseIP(buf[i], 0, this.ipv6),
+                 port: port
+               })
   }
 
   return peers

--- a/test/abort.js
+++ b/test/abort.js
@@ -2,12 +2,13 @@ var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
 
-test('explicitly set nodeId', function (t) {
+common.wrapTest(test, 'explicitly set nodeId', function genericTest (t, ipv6) {
   var nodeId = common.randomId()
 
   var dht = new DHT({
     nodeId: nodeId,
-    bootstrap: false
+    bootstrap: false,
+    ipv6: ipv6
   })
 
   common.failOnWarningOrError(t, dht)

--- a/test/announce.js
+++ b/test/announce.js
@@ -2,9 +2,9 @@ var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
 
-test('`announce` with {host: false}', function (t) {
+common.wrapTest(test, '`announce` with {host: false}', function (t, ipv6) {
   t.plan(3)
-  var dht = new DHT({ bootstrap: false, host: false })
+  var dht = new DHT({ bootstrap: false, host: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht)
 
   var infoHash = common.randomId()
@@ -18,9 +18,10 @@ test('`announce` with {host: false}', function (t) {
   })
 })
 
-test('`announce` with {host: "127.0.0.1"}', function (t) {
+common.wrapTest(test, '`announce` with {host: "127.0.0.1"}', function (t, ipv6) {
   t.plan(3)
-  var dht = new DHT({ bootstrap: false, host: '127.0.0.1' })
+
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6, host: common.localHost(ipv6) })
   common.failOnWarningOrError(t, dht)
 
   var infoHash = common.randomId()
@@ -32,26 +33,26 @@ test('`announce` with {host: "127.0.0.1"}', function (t) {
     })
 
     dht.on('peer', function (peer) {
-      t.deepEqual(peer, { host: '127.0.0.1', port: 6969 })
+      t.deepEqual(peer, { host: common.localHost(ipv6), port: 6969 })
     })
   })
 })
 
-test('announce with implied port', function (t) {
+common.wrapTest(test, 'announce with implied port', function (t, ipv6) {
   t.plan(2)
-  var dht1 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
   var infoHash = common.randomId()
 
   dht1.listen(function () {
-    var dht2 = new DHT({bootstrap: '127.0.0.1:' + dht1.address().port})
+    var dht2 = new DHT({ipv6: ipv6, bootstrap: (ipv6 ? '[::1]:' : '127.0.0.1:') + dht1.address().port}) // Test parsing port
 
     dht1.on('announce', function (peer) {
-      t.deepEqual(peer, {host: '127.0.0.1', port: dht2.address().port})
+      t.deepEqual(peer, {host: common.localHost(ipv6), port: dht2.address().port})
     })
 
     dht2.announce(infoHash, function () {
       dht2.once('peer', function (peer) {
-        t.deepEqual(peer, {host: '127.0.0.1', port: dht2.address().port})
+        t.deepEqual(peer, {host: common.localHost(ipv6), port: dht2.address().port})
         dht1.destroy()
         dht2.destroy()
       })

--- a/test/announce.js
+++ b/test/announce.js
@@ -21,7 +21,7 @@ common.wrapTest(test, '`announce` with {host: false}', function (t, ipv6) {
 common.wrapTest(test, '`announce` with {host: "127.0.0.1"}', function (t, ipv6) {
   t.plan(3)
 
-  var dht = new DHT({ bootstrap: false, ipv6: ipv6, host: common.localHost(ipv6) })
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6, host: common.localHost(ipv6, true) })
   common.failOnWarningOrError(t, dht)
 
   var infoHash = common.randomId()
@@ -33,7 +33,7 @@ common.wrapTest(test, '`announce` with {host: "127.0.0.1"}', function (t, ipv6) 
     })
 
     dht.on('peer', function (peer) {
-      t.deepEqual(peer, { host: common.localHost(ipv6), port: 6969 })
+      t.deepEqual(peer, { host: common.localHost(ipv6, true), port: 6969 })
     })
   })
 })
@@ -47,12 +47,12 @@ common.wrapTest(test, 'announce with implied port', function (t, ipv6) {
     var dht2 = new DHT({ipv6: ipv6, bootstrap: (ipv6 ? '[::1]:' : '127.0.0.1:') + dht1.address().port}) // Test parsing port
 
     dht1.on('announce', function (peer) {
-      t.deepEqual(peer, {host: common.localHost(ipv6), port: dht2.address().port})
+      t.deepEqual(peer, {host: common.localHost(ipv6, true), port: dht2.address().port})
     })
 
     dht2.announce(infoHash, function () {
       dht2.once('peer', function (peer) {
-        t.deepEqual(peer, {host: common.localHost(ipv6), port: dht2.address().port})
+        t.deepEqual(peer, {host: common.localHost(ipv6, true), port: dht2.address().port})
         dht1.destroy()
         dht2.destroy()
       })

--- a/test/basic.js
+++ b/test/basic.js
@@ -27,13 +27,13 @@ common.wrapTest(test, 'call `addNode` with nodeId argument', function (t, ipv6) 
   var nodeId = common.randomId()
 
   dht.on('node', function (node) {
-    t.equal(node.host, common.localHost(ipv6))
+    t.equal(node.host, common.localHost(ipv6, true))
     t.equal(node.port, 9999)
     t.deepEqual(node.id, nodeId)
     dht.destroy()
   })
 
-  dht.addNode({host: common.localHost(ipv6), port: 9999, id: nodeId})
+  dht.addNode({host: common.localHost(ipv6, true), port: 9999, id: nodeId})
 })
 
 common.wrapTest(test, 'call `addNode` without nodeId argument', function (t, ipv6) {
@@ -49,10 +49,10 @@ common.wrapTest(test, 'call `addNode` without nodeId argument', function (t, ipv
     var port = dht1.address().port
 
     // If `nodeId` is undefined, then the peer will be pinged to learn their node id.
-    dht2.addNode({host: common.localHost(ipv6), port: port})
+    dht2.addNode({host: common.localHost(ipv6, true), port: port})
 
     dht2.on('node', function (node) {
-      t.equal(node.host, common.localHost(ipv6))
+      t.equal(node.host, common.localHost(ipv6, true))
       t.equal(node.port, port)
       t.deepEqual(node.id, dht1.nodeId)
       dht1.destroy()
@@ -69,7 +69,7 @@ common.wrapTest(test, 'call `addNode` without nodeId argument, and invalid addr'
 
   // If `nodeId` is undefined, then the peer will be pinged to learn their node id.
   // If the peer DOES NOT RESPOND, the will not be added to the routing table.
-  dht.addNode({host: common.localHost(ipv6), port: 9999})
+  dht.addNode({host: common.localHost(ipv6, true), port: 9999})
 
   dht.on('node', function () {
     // No 'node' event should be emitted if the added node does not respond to ping
@@ -93,7 +93,7 @@ common.wrapTest(test, '`addNode` only emits events for new nodes', function (t, 
   })
 
   var nodeId = common.randomId()
-  var addr = common.localHost(ipv6)
+  var addr = common.localHost(ipv6, true)
   dht.addNode({host: addr, port: 9999, id: nodeId})
   dht.addNode({host: addr, port: 9999, id: nodeId})
   dht.addNode({host: addr, port: 9999, id: nodeId})
@@ -113,7 +113,7 @@ common.wrapTest(test, 'send message while binding (listen)', function (t, ipv6) 
     var port = a.address().port
     var b = new DHT({ bootstrap: false, ipv6: ipv6 })
     b.listen()
-    b._sendPing({host: common.localHost(ipv6), port: port}, function (err) {
+    b._sendPing({host: common.localHost(ipv6, true), port: port}, function (err) {
       t.error(err)
       a.destroy()
       b.destroy()

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -3,13 +3,14 @@ var DHT = require('../')
 var test = require('tape')
 
 // https://github.com/feross/bittorrent-dht/pull/36
-test('bootstrap and listen to custom port', function (t) {
+common.wrapTest(test, 'bootstrap and listen to custom port', function (t, ipv6) {
   t.plan(4)
 
-  var dht = new DHT({ bootstrap: [ '1.2.3.4:1000' ] })
+  var dht = new DHT({ ipv6: ipv6, bootstrap: [ ipv6 ? '[::2]:1000' : '1.2.3.4:1000' ] })
   common.failOnWarningOrError(t, dht)
 
   var port = Math.floor(Math.random() * 60000) + 1024
+  self = this
 
   t.ok(!dht.listening)
   dht.listen(port)

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -10,7 +10,6 @@ common.wrapTest(test, 'bootstrap and listen to custom port', function (t, ipv6) 
   common.failOnWarningOrError(t, dht)
 
   var port = Math.floor(Math.random() * 60000) + 1024
-  self = this
 
   t.ok(!dht.listening)
   dht.listen(port)

--- a/test/common.js
+++ b/test/common.js
@@ -10,8 +10,7 @@ exports.failOnWarningOrError = function (t, dht) {
 }
 
 exports.randomHost = function (ipv6) {
-  // We only use 15 random bits for the IPv6 because of a bug with ip-addr
-  return ipv6 ? Address6.fromByteArray(crypto.randomBytes(15)).correctForm() : ip.toString(crypto.randomBytes(4))
+  return ipv6 ? Address6.fromByteArray(crypto.randomBytes(16)).correctForm() : ip.toString(crypto.randomBytes(4))
 }
 
 exports.randomPort = function () {

--- a/test/common.js
+++ b/test/common.js
@@ -2,22 +2,24 @@ var Buffer = require('safe-buffer').Buffer
 var crypto = require('crypto')
 var ed = require('ed25519-supercop')
 var ip = require('ip')
+var Address6 = require('ip-address').Address6;
 
 exports.failOnWarningOrError = function (t, dht) {
   dht.on('warning', function (err) { t.fail(err) })
   dht.on('error', function (err) { t.fail(err) })
 }
 
-exports.randomHost = function () {
-  return ip.toString(crypto.randomBytes(4))
+exports.randomHost = function (ipv6) {
+  // We only use 15 random bits for the IPv6 because of a bug with ip-addr
+  return ipv6 ? Address6.fromByteArray(crypto.randomBytes(15)).correctForm() : ip.toString(crypto.randomBytes(4))
 }
 
 exports.randomPort = function () {
   return crypto.randomBytes(2).readUInt16LE(0)
 }
 
-exports.randomAddr = function () {
-  return { host: exports.randomHost(), port: exports.randomPort() }
+exports.randomAddr = function (ipv6) {
+  return { host: exports.randomHost(ipv6), port: exports.randomPort() }
 }
 
 exports.randomId = function () {
@@ -34,9 +36,9 @@ exports.addRandomNodes = function (dht, num) {
   }
 }
 
-exports.addRandomPeers = function (dht, num) {
+exports.addRandomPeers = function (dht, num, ipv6) {
   for (var i = 0; i < num; i++) {
-    dht._addPeer(exports.randomAddr(), exports.randomId())
+    dht._addPeer(exports.randomAddr(ipv6), exports.randomId())
   }
 }
 

--- a/test/common.js
+++ b/test/common.js
@@ -54,3 +54,23 @@ exports.sign = function (keypair) {
     return ed.sign(buf, keypair.publicKey, keypair.secretKey)
   }
 }
+
+exports.localHost = function (ipv6) {
+  return ipv6 ? '::1' : '127.0.0.1'
+}
+
+exports.wrapTest = function (test, str, func) {
+  test('ipv4 ' + str, function(t) {
+    func(t, false)
+    if (t._plan) {
+      t.plan(t._plan + 1)
+    }
+
+    t.test('ipv6 ' + str, function(newT) {
+      func(newT, true)
+    })
+  })
+  /*test('ipv4' + str, function (t) {
+    func(t, false)
+  })*/
+}

--- a/test/common.js
+++ b/test/common.js
@@ -2,7 +2,7 @@ var Buffer = require('safe-buffer').Buffer
 var crypto = require('crypto')
 var ed = require('ed25519-supercop')
 var ip = require('ip')
-var Address6 = require('ip-address').Address6;
+var Address6 = require('ip-address').Address6
 
 exports.failOnWarningOrError = function (t, dht) {
   dht.on('warning', function (err) { t.fail(err) })
@@ -26,11 +26,11 @@ exports.randomId = function () {
   return crypto.randomBytes(20)
 }
 
-exports.addRandomNodes = function (dht, num) {
+exports.addRandomNodes = function (dht, num, ipv6) {
   for (var i = 0; i < num; i++) {
     dht.addNode({
       id: exports.randomId(),
-      host: exports.randomHost(),
+      host: exports.randomHost(ipv6),
       port: exports.randomPort()
     })
   }
@@ -57,22 +57,25 @@ exports.sign = function (keypair) {
   }
 }
 
-exports.localHost = function (ipv6) {
-  return ipv6 ? '::1' : '127.0.0.1'
+exports.localHost = function (ipv6, plainIpv6) {
+  if (ipv6) {
+    if (!plainIpv6) {
+      return '[::1]'
+    }
+    return '::1'
+  }
+  return '127.0.0.1'
 }
 
 exports.wrapTest = function (test, str, func) {
-  test('ipv4 ' + str, function(t) {
+  test('ipv4 ' + str, function (t) {
     func(t, false)
     if (t._plan) {
       t.plan(t._plan + 1)
     }
 
-    t.test('ipv6 ' + str, function(newT) {
+    t.test('ipv6 ' + str, function (newT) {
       func(newT, true)
     })
   })
-  /*test('ipv4' + str, function (t) {
-    func(t, false)
-  })*/
 }

--- a/test/dht_store_immutable.js
+++ b/test/dht_store_immutable.js
@@ -48,7 +48,7 @@ common.wrapTest(test, 'delegated put', function (t, ipv6) {
   common.failOnWarningOrError(t, dht3)
   common.failOnWarningOrError(t, dht4)
 
-  var host = common.localHost(ipv6)
+  var host = common.localHost(ipv6, true)
 
   var pending = 4
   dht1.listen(function () {
@@ -112,11 +112,11 @@ common.wrapTest(test, 'multi-party immutable put/get', function (t, ipv6) {
 
   var pending = 2
   dht1.listen(function () {
-    dht2.addNode({ host: common.localHost(ipv6), port: dht1.address().port })
+    dht2.addNode({ host: common.localHost(ipv6, true), port: dht1.address().port })
     dht2.once('node', ready)
   })
   dht2.listen(function () {
-    dht1.addNode({ host: common.localHost(ipv6), port: dht2.address().port })
+    dht1.addNode({ host: common.localHost(ipv6, true), port: dht2.address().port })
     dht1.once('node', ready)
   })
 

--- a/test/dht_store_immutable.js
+++ b/test/dht_store_immutable.js
@@ -2,10 +2,10 @@ var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
 
-test('local immutable put/get', function (t) {
+common.wrapTest(test, 'local immutable put/get', function (t, ipv6) {
   t.plan(3)
 
-  var dht = new DHT({ bootstrap: false })
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
   t.once('end', function () {
     dht.destroy()
   })
@@ -28,13 +28,13 @@ test('local immutable put/get', function (t) {
   })
 })
 
-test('delegated put', function (t) {
+common.wrapTest(test, 'delegated put', function (t, ipv6) {
   t.plan(5)
 
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
-  var dht3 = new DHT({ bootstrap: false })
-  var dht4 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht3 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht4 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   t.once('end', function () {
     dht1.destroy()
@@ -48,24 +48,26 @@ test('delegated put', function (t) {
   common.failOnWarningOrError(t, dht3)
   common.failOnWarningOrError(t, dht4)
 
+  var host = common.localHost(ipv6)
+
   var pending = 4
   dht1.listen(function () {
-    dht2.addNode({ host: '127.0.0.1', port: dht1.address().port })
+    dht2.addNode({ host: host, port: dht1.address().port })
     dht2.once('node', ready)
   })
 
   dht2.listen(function () {
-    dht1.addNode({ host: '127.0.0.1', port: dht2.address().port })
+    dht1.addNode({ host: host, port: dht2.address().port })
     dht1.once('node', ready)
   })
 
   dht3.listen(function () {
-    dht4.addNode({ host: '127.0.0.1', port: dht3.address().port })
+    dht4.addNode({ host: host, port: dht3.address().port })
     dht4.once('node', ready)
   })
 
   dht4.listen(function () {
-    dht3.addNode({ host: '127.0.0.1', port: dht4.address().port })
+    dht3.addNode({ host: host, port: dht4.address().port })
     dht3.once('node', ready)
   })
 
@@ -95,11 +97,11 @@ test('delegated put', function (t) {
   }
 })
 
-test('multi-party immutable put/get', function (t) {
+common.wrapTest(test, 'multi-party immutable put/get', function (t, ipv6) {
   t.plan(4)
 
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
   t.once('end', function () {
     dht1.destroy()
     dht2.destroy()
@@ -110,11 +112,11 @@ test('multi-party immutable put/get', function (t) {
 
   var pending = 2
   dht1.listen(function () {
-    dht2.addNode({ host: '127.0.0.1', port: dht1.address().port })
+    dht2.addNode({ host: common.localHost(ipv6), port: dht1.address().port })
     dht2.once('node', ready)
   })
   dht2.listen(function () {
-    dht1.addNode({ host: '127.0.0.1', port: dht2.address().port })
+    dht1.addNode({ host: common.localHost(ipv6), port: dht2.address().port })
     dht1.once('node', ready)
   })
 

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -4,12 +4,12 @@ var ed = require('ed25519-supercop')
 var test = require('tape')
 var crypto = require('crypto')
 
-test('local mutable put/get', function (t) {
+/*common.wrapTest(test, 'local mutable put/get', function (t, ipv6) {
   t.plan(4)
 
   var keypair = ed.createKeyPair(ed.createSeed())
 
-  var dht = new DHT({ bootstrap: false, verify: ed.verify })
+  var dht = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
   t.once('end', function () {
     dht.destroy()
   })
@@ -43,13 +43,13 @@ test('local mutable put/get', function (t) {
   })
 })
 
-test('multiparty mutable put/get', function (t) {
+common.wrapTest(test, 'multiparty mutable put/get', function (t, ipv6) {
   t.plan(4)
 
   var keypair = ed.createKeyPair(ed.createSeed())
 
-  var dht1 = new DHT({ bootstrap: false, verify: ed.verify })
-  var dht2 = new DHT({ bootstrap: false, verify: ed.verify })
+  var dht1 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
 
   t.once('end', function () {
     dht1.destroy()
@@ -60,12 +60,12 @@ test('multiparty mutable put/get', function (t) {
 
   var pending = 2
   dht1.listen(function () {
-    dht2.addNode({ host: '127.0.0.1', port: dht1.address().port })
+    dht2.addNode({ host: common.localHost(ipv6), port: dht1.address().port })
     dht2.once('node', ready)
   })
 
   dht2.listen(function () {
-    dht1.addNode({ host: '127.0.0.1', port: dht2.address().port })
+    dht1.addNode({ host: common.localHost(ipv6), port: dht2.address().port })
     dht1.once('node', ready)
   })
 
@@ -95,15 +95,15 @@ test('multiparty mutable put/get', function (t) {
   }
 })
 
-test('delegated put', function (t) {
+common.wrapTest(test, 'delegated put', function (t, ipv6) {
   t.plan(5)
 
   var keypair = ed.createKeyPair(ed.createSeed())
 
-  var dht1 = new DHT({ bootstrap: false, verify: ed.verify })
-  var dht2 = new DHT({ bootstrap: false, verify: ed.verify })
-  var dht3 = new DHT({ bootstrap: false, verify: ed.verify })
-  var dht4 = new DHT({ bootstrap: false, verify: ed.verify })
+  var dht1 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
+  var dht3 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
+  var dht4 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
 
   t.once('end', function () {
     dht1.destroy()
@@ -118,23 +118,25 @@ test('delegated put', function (t) {
   common.failOnWarningOrError(t, dht4)
 
   var pending = 4
+  var host = common.localHost(ipv6);
+
   dht1.listen(function () {
-    dht2.addNode({ host: '127.0.0.1', port: dht1.address().port })
+    dht2.addNode({ host: host, port: dht1.address().port })
     dht2.once('node', ready)
   })
 
   dht2.listen(function () {
-    dht1.addNode({ host: '127.0.0.1', port: dht2.address().port })
+    dht1.addNode({ host: host, port: dht2.address().port })
     dht1.once('node', ready)
   })
 
   dht3.listen(function () {
-    dht4.addNode({ host: '127.0.0.1', port: dht3.address().port })
+    dht4.addNode({ host: host, port: dht3.address().port })
     dht4.once('node', ready)
   })
 
   dht4.listen(function () {
-    dht3.addNode({ host: '127.0.0.1', port: dht4.address().port })
+    dht3.addNode({ host: host, port: dht4.address().port })
     dht3.once('node', ready)
   })
 
@@ -165,7 +167,7 @@ test('delegated put', function (t) {
       })
     })
   }
-})
+})*/
 
 test('multiparty mutable put/get sequence', function (t) {
   t.plan(12)

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -169,90 +169,6 @@ common.wrapTest(test, 'delegated put', function (t, ipv6) {
   }
 })
 
-test('mutable update mesh', function (t) {
-  t.plan(12)
-  /*
-   0 <-> 1 <-> 2
-   ^     ^
-   |     |
-   v     v
-   3 <-> 4 <-> 5
-   ^           ^
-   |           |
-   v           v
-   6 <-> 7 <-> 8
-
-   tests: 0 to 8, 4 to 6, 1 to 5
-   */
-  var edges = [
-    [0, 1], [1, 2], [1, 3], [2, 4], [3, 4], [3, 6],
-    [4, 5], [5, 8], [6, 7], [7, 8]
-  ]
-
-  var dht = []
-  var pending = 0
-  for (var i = 0; i < 9; i++) {
-    (function (i) {
-      var d = new DHT({ bootstrap: false, verify: ed.verify })
-      dht.push(d)
-      common.failOnWarningOrError(t, d)
-      pending++
-      d.listen(function () {
-        if (--pending === 0) addEdges()
-      })
-    })(i)
-  }
-
-  function addEdges () {
-    var pending = edges.length
-    for (var i = 0; i < edges.length; i++) {
-      (function (e) {
-        dht[e[1]].addNode({ host: '127.0.0.1', port: dht[e[0]].address().port })
-        dht[e[1]].once('node', function () {
-          if (--pending === 0) ready()
-        })
-      })(edges[i])
-    }
-  }
-
-  t.once('end', function () {
-    for (var i = 0; i < dht.length; i++) {
-      dht[i].destroy()
-    }
-  })
-
-  function ready () {
-    send(0, 8, common.fill(100, 'abc'))
-    send(4, 6, common.fill(20, 'xyz'))
-    send(1, 5, common.fill(500, 'whatever'))
-  }
-
-  function send (srci, dsti, value) {
-    var src = dht[srci]
-    var dst = dht[dsti]
-    var keypair = ed.createKeyPair(ed.createSeed())
-    var opts = {
-      k: keypair.publicKey,
-      sign: common.sign(keypair),
-      seq: 0,
-      v: value
-    }
-
-    var xhash = crypto.createHash('sha1').update(opts.k).digest()
-    src.put(opts, function (err, hash) {
-      t.error(err)
-      t.equal(hash.toString('hex'), xhash.toString('hex'))
-
-      dst.get(xhash, function (err, res) {
-        t.ifError(err)
-        t.equal(res.v.toString('utf8'), opts.v.toString('utf8'),
-                'from ' + srci + ' to ' + dsti
-        )
-      })
-    })
-  }
-})
-
 test('multiparty mutable put/get sequence', function (t) {
   t.plan(12)
 
@@ -337,6 +253,90 @@ test('multiparty mutable put/get sequence', function (t) {
         })
       })
     }
+  }
+})
+
+test('mutable update mesh', function (t) {
+  t.plan(12)
+  /*
+   0 <-> 1 <-> 2
+   ^     ^
+   |     |
+   v     v
+   3 <-> 4 <-> 5
+   ^           ^
+   |           |
+   v           v
+   6 <-> 7 <-> 8
+
+   tests: 0 to 8, 4 to 6, 1 to 5
+   */
+  var edges = [
+    [0, 1], [1, 2], [1, 3], [2, 4], [3, 4], [3, 6],
+    [4, 5], [5, 8], [6, 7], [7, 8]
+  ]
+
+  var dht = []
+  var pending = 0
+  for (var i = 0; i < 9; i++) {
+    (function (i) {
+      var d = new DHT({ bootstrap: false, verify: ed.verify })
+      dht.push(d)
+      common.failOnWarningOrError(t, d)
+      pending++
+      d.listen(function () {
+        if (--pending === 0) addEdges()
+      })
+    })(i)
+  }
+
+  function addEdges () {
+    var pending = edges.length
+    for (var i = 0; i < edges.length; i++) {
+      (function (e) {
+        dht[e[1]].addNode({ host: '127.0.0.1', port: dht[e[0]].address().port })
+        dht[e[1]].once('node', function () {
+          if (--pending === 0) ready()
+        })
+      })(edges[i])
+    }
+  }
+
+  t.once('end', function () {
+    for (var i = 0; i < dht.length; i++) {
+      dht[i].destroy()
+    }
+  })
+
+  function ready () {
+    send(0, 8, common.fill(100, 'abc'))
+    send(4, 6, common.fill(20, 'xyz'))
+    send(1, 5, common.fill(500, 'whatever'))
+  }
+
+  function send (srci, dsti, value) {
+    var src = dht[srci]
+    var dst = dht[dsti]
+    var keypair = ed.createKeyPair(ed.createSeed())
+    var opts = {
+      k: keypair.publicKey,
+      sign: common.sign(keypair),
+      seq: 0,
+      v: value
+    }
+
+    var xhash = crypto.createHash('sha1').update(opts.k).digest()
+    src.put(opts, function (err, hash) {
+      t.error(err)
+      t.equal(hash.toString('hex'), xhash.toString('hex'))
+
+      dst.get(xhash, function (err, res) {
+        t.ifError(err)
+        t.equal(res.v.toString('utf8'), opts.v.toString('utf8'),
+                'from ' + srci + ' to ' + dsti
+        )
+      })
+    })
   }
 })
 

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -4,7 +4,7 @@ var ed = require('ed25519-supercop')
 var test = require('tape')
 var crypto = require('crypto')
 
-/*common.wrapTest(test, 'local mutable put/get', function (t, ipv6) {
+common.wrapTest(test, 'local mutable put/get', function (t, ipv6) {
   t.plan(4)
 
   var keypair = ed.createKeyPair(ed.createSeed())
@@ -60,12 +60,12 @@ common.wrapTest(test, 'multiparty mutable put/get', function (t, ipv6) {
 
   var pending = 2
   dht1.listen(function () {
-    dht2.addNode({ host: common.localHost(ipv6), port: dht1.address().port })
+    dht2.addNode({ host: common.localHost(ipv6, true), port: dht1.address().port })
     dht2.once('node', ready)
   })
 
   dht2.listen(function () {
-    dht1.addNode({ host: common.localHost(ipv6), port: dht2.address().port })
+    dht1.addNode({ host: common.localHost(ipv6, true), port: dht2.address().port })
     dht1.once('node', ready)
   })
 
@@ -118,7 +118,7 @@ common.wrapTest(test, 'delegated put', function (t, ipv6) {
   common.failOnWarningOrError(t, dht4)
 
   var pending = 4
-  var host = common.localHost(ipv6);
+  var host = common.localHost(ipv6, true)
 
   dht1.listen(function () {
     dht2.addNode({ host: host, port: dht1.address().port })
@@ -167,7 +167,7 @@ common.wrapTest(test, 'delegated put', function (t, ipv6) {
       })
     })
   }
-})*/
+})
 
 test('mutable update mesh', function (t) {
   t.plan(12)
@@ -252,7 +252,6 @@ test('mutable update mesh', function (t) {
     })
   }
 })
-/*
 
 test('multiparty mutable put/get sequence', function (t) {
   t.plan(12)
@@ -493,8 +492,6 @@ test('transitive mutable update', function (t) {
   }
 })
 
-
-
 test('invalid sequence', function (t) {
   t.plan(5)
 
@@ -612,4 +609,3 @@ test('valid sequence', function (t) {
     }
   })
 })
-*/

--- a/test/dht_test_vectors.js
+++ b/test/dht_test_vectors.js
@@ -5,7 +5,7 @@ var crypto = require('crypto')
 var ed = require('ed25519-supercop')
 
 // test vectors from http://bittorrent.org/beps/bep_0044.html
-test('dht store test vectors', function (t) {
+common.wrapTest(test, 'dht store test vectors', function (t, ipv6) {
   t.plan(6)
 
   var pub = Buffer(
@@ -19,7 +19,7 @@ test('dht store test vectors', function (t) {
   )
   var value = 'Hello World!'
 
-  var dht = new DHT({ bootstrap: false, verify: ed.verify })
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6, verify: ed.verify })
   t.once('end', function () {
     dht.destroy()
   })

--- a/test/events.js
+++ b/test/events.js
@@ -2,8 +2,8 @@ var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
 
-test('`node` event fires for each added node (100x)', function (t) {
-  var dht = new DHT({ bootstrap: false })
+common.wrapTest(test, '`node` event fires for each added node (100x)', function (t, ipv6) {
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht)
 
   var numNodes = 0
@@ -19,8 +19,8 @@ test('`node` event fires for each added node (100x)', function (t) {
   common.addRandomNodes(dht, 100)
 })
 
-test('`node` event fires for each added node (10000x)', function (t) {
-  var dht = new DHT({ bootstrap: false })
+common.wrapTest(test, '`node` event fires for each added node (10000x)', function (t, ipv6) {
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht)
 
   var numNodes = 0
@@ -36,8 +36,8 @@ test('`node` event fires for each added node (10000x)', function (t) {
   common.addRandomNodes(dht, 10000)
 })
 
-test('`announce` event fires for each added peer (100x)', function (t) {
-  var dht = new DHT({ bootstrap: false })
+common.wrapTest(test, '`announce` event fires for each added peer (100x)', function (t, ipv6) {
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht)
 
   var numPeers = 0
@@ -50,11 +50,11 @@ test('`announce` event fires for each added peer (100x)', function (t) {
     }
   })
 
-  common.addRandomPeers(dht, 100)
+  common.addRandomPeers(dht, 100, ipv6)
 })
 
-test('`announce` event fires for each added peer (10000x)', function (t) {
-  var dht = new DHT({ bootstrap: false })
+common.wrapTest(test, '`announce` event fires for each added peer (10000x)', function (t, ipv6) {
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht)
 
   var numPeers = 0
@@ -67,12 +67,12 @@ test('`announce` event fires for each added peer (10000x)', function (t) {
     }
   })
 
-  common.addRandomPeers(dht, 10000)
+  common.addRandomPeers(dht, 10000, ipv6)
 })
 
-test('`listening` event fires', function (t) {
+common.wrapTest(test, '`listening` event fires', function (t, ipv6) {
   t.plan(2)
-  var dht = new DHT({ bootstrap: false })
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht)
 
@@ -85,9 +85,9 @@ test('`listening` event fires', function (t) {
   })
 })
 
-test('`ready` event fires when bootstrap === false', function (t) {
+common.wrapTest(test, '`ready` event fires when bootstrap === false', function (t, ipv6) {
   t.plan(2)
-  var dht = new DHT({ bootstrap: false })
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht)
 
@@ -98,11 +98,11 @@ test('`ready` event fires when bootstrap === false', function (t) {
   })
 })
 
-test('`ready` event fires when there are K nodes', function (t) {
+common.wrapTest(test, '`ready` event fires when there are K nodes', function (t, ipv6) {
   t.plan(6)
 
   // dht1 will simulate an existing node (with a populated routing table)
-  var dht1 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht1)
 
   dht1.on('ready', function () {
@@ -117,7 +117,7 @@ test('`ready` event fires when there are K nodes', function (t) {
       t.pass('dht1 listening on port ' + port)
 
       // dht2 will get all 3 nodes from dht1 and should also emit a `ready` event
-      var dht2 = new DHT({ bootstrap: '127.0.0.1:' + port })
+      var dht2 = new DHT({ bootstrap: common.localHost(ipv6) + ':' +  port })
       common.failOnWarningOrError(t, dht2)
 
       dht2.on('ready', function () {

--- a/test/events.js
+++ b/test/events.js
@@ -1,6 +1,11 @@
 var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
+/* var log = require('why-is-node-running')
+
+setInterval(function () {
+  log() // logs out active handles that are keeping node running
+}, 10000) */
 
 common.wrapTest(test, '`node` event fires for each added node (100x)', function (t, ipv6) {
   var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
@@ -16,7 +21,7 @@ common.wrapTest(test, '`node` event fires for each added node (100x)', function 
     }
   })
 
-  common.addRandomNodes(dht, 100)
+  common.addRandomNodes(dht, 100, ipv6)
 })
 
 common.wrapTest(test, '`node` event fires for each added node (10000x)', function (t, ipv6) {
@@ -33,7 +38,7 @@ common.wrapTest(test, '`node` event fires for each added node (10000x)', functio
     }
   })
 
-  common.addRandomNodes(dht, 10000)
+  common.addRandomNodes(dht, 10000, ipv6)
 })
 
 common.wrapTest(test, '`announce` event fires for each added peer (100x)', function (t, ipv6) {
@@ -98,6 +103,13 @@ common.wrapTest(test, '`ready` event fires when bootstrap === false', function (
   })
 })
 
+common.wrapTest(test, 'add node with opposite protocol address', function (t, ipv6) {
+  t.plan(1)
+  var dht = new DHT({ bootstrap: false, ipv6: ipv6 })
+  t.throws(function () { common.addRandomNodes(dht, 1, !ipv6) }, /Address protocol mismatch!/, 'should throw an error')
+  dht.destroy()
+})
+
 common.wrapTest(test, '`ready` event fires when there are K nodes', function (t, ipv6) {
   t.plan(6)
 
@@ -109,7 +121,7 @@ common.wrapTest(test, '`ready` event fires when there are K nodes', function (t,
     t.pass('dht1 `ready` event fires because { bootstrap: false }')
     t.equal(dht1.ready, true)
 
-    common.addRandomNodes(dht1, 3)
+    common.addRandomNodes(dht1, 3, ipv6)
     t.equal(dht1.nodes.count(), 3, 'dht1 has 3 nodes')
 
     dht1.listen(function () {
@@ -117,7 +129,7 @@ common.wrapTest(test, '`ready` event fires when there are K nodes', function (t,
       t.pass('dht1 listening on port ' + port)
 
       // dht2 will get all 3 nodes from dht1 and should also emit a `ready` event
-      var dht2 = new DHT({ bootstrap: common.localHost(ipv6) + ':' +  port })
+      var dht2 = new DHT({ ipv6: ipv6, bootstrap: common.localHost(ipv6, false) + ':' + port })
       common.failOnWarningOrError(t, dht2)
 
       dht2.on('ready', function () {
@@ -131,3 +143,4 @@ common.wrapTest(test, '`ready` event fires when there are K nodes', function (t,
     })
   })
 })
+

--- a/test/internal.js
+++ b/test/internal.js
@@ -3,17 +3,17 @@ var common = require('./common')
 var DHT = require('../')
 var test = require('tape')
 
-test('`ping` query send and response', function (t) {
+common.wrapTest(test, '`ping` query send and response', function (t, ipv6) {
   t.plan(2)
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
   dht1.listen(function () {
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: dht1.address().port
     }, {
       q: 'ping'
@@ -27,21 +27,21 @@ test('`ping` query send and response', function (t) {
   })
 })
 
-test('`find_node` query for exact match (with one in table)', function (t) {
+common.wrapTest(test, '`find_node` query for exact match (with one in table)', function (t, ipv6) {
   t.plan(3)
   var targetNodeId = common.randomId()
 
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
-  dht1.addNode({host: '255.255.255.255', port: 6969, id: targetNodeId})
+  dht1.addNode({host: common.randomHost(ipv6), port: 6969, id: targetNodeId})
 
   dht1.listen(function () {
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: dht1.address().port
     }, {
       q: 'find_node',
@@ -50,7 +50,7 @@ test('`find_node` query for exact match (with one in table)', function (t) {
       t.error(err)
 
       t.deepEqual(res.r.id, dht1.nodeId)
-      t.deepEqual(res.r.nodes.length, 2 * 26)
+      t.deepEqual(getNodes(res, ipv6).length, 2 * getNodeLength(ipv6))
 
       dht1.destroy()
       dht2.destroy()
@@ -58,22 +58,22 @@ test('`find_node` query for exact match (with one in table)', function (t) {
   })
 })
 
-test('`find_node` query (with many in table)', function (t) {
+common.wrapTest(test, '`find_node` query (with many in table)', function (t, ipv6) {
   t.plan(3)
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
-  dht1.addNode({host: '1.1.1.1', port: 6969, id: common.randomId()})
-  dht1.addNode({host: '10.10.10.10', port: 6969, id: common.randomId()})
-  dht1.addNode({host: '255.255.255.255', port: 6969, id: common.randomId()})
+  dht1.addNode({host: common.randomHost(ipv6), port: 6969, id: common.randomId()})
+  dht1.addNode({host: common.randomHost(ipv6), port: 6969, id: common.randomId()})
+  dht1.addNode({host: common.randomHost(ipv6), port: 6969, id: common.randomId()})
 
   dht1.listen(function () {
     var targetNodeId = common.randomId()
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: dht1.address().port
     }, {
       q: 'find_node',
@@ -82,7 +82,7 @@ test('`find_node` query (with many in table)', function (t) {
       t.error(err)
 
       t.deepEqual(res.r.id, dht1.nodeId)
-      t.deepEqual(res.r.nodes.length, 26 * 4)
+      t.deepEqual(getNodes(res, ipv6).length, getNodeLength(ipv6) * 4)
 
       dht1.destroy()
       dht2.destroy()
@@ -90,21 +90,21 @@ test('`find_node` query (with many in table)', function (t) {
   })
 })
 
-test('`get_peers` query to node with *no* peers in table', function (t) {
+common.wrapTest(test, '`get_peers` query to node with *no* peers in table', function (t, ipv6) {
   t.plan(4)
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
-  dht1.addNode({host: '1.1.1.1', port: 6969, id: common.randomId()})
-  dht1.addNode({host: '2.2.2.2', port: 6969, id: common.randomId()})
+  dht1.addNode({host: common.randomHost(ipv6), port: 6969, id: common.randomId()})
+  dht1.addNode({host: common.randomHost(ipv6), port: 6969, id: common.randomId()})
 
   dht1.listen(function () {
     var targetInfoHash = common.randomId()
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: dht1.address().port
     }, {
       q: 'get_peers',
@@ -115,7 +115,7 @@ test('`get_peers` query to node with *no* peers in table', function (t) {
       t.error(err)
       t.deepEqual(res.r.id, dht1.nodeId)
       t.ok(Buffer.isBuffer(res.r.token))
-      t.deepEqual(res.r.nodes.length, 3 * 26)
+      t.deepEqual(getNodes(res, ipv6).length, 3 * getNodeLength(ipv6))
 
       dht1.destroy()
       dht2.destroy()
@@ -123,24 +123,24 @@ test('`get_peers` query to node with *no* peers in table', function (t) {
   })
 })
 
-test('`get_peers` query to node with peers in table', function (t) {
+common.wrapTest(test, '`get_peers` query to node with peers in table', function (t, ipv6) {
   t.plan(4)
 
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
 
   var targetInfoHash = common.randomId()
 
-  dht1._addPeer({ host: '1.1.1.1', port: 6969 }, targetInfoHash)
-  dht1._addPeer({ host: '10.10.10.10', port: 6969 }, targetInfoHash)
-  dht1._addPeer({ host: '255.255.255.255', port: 6969 }, targetInfoHash)
+  dht1._addPeer({ host: common.randomHost(ipv6), port: 6969 }, targetInfoHash)
+  dht1._addPeer({ host: common.randomHost(ipv6), port: 6969 }, targetInfoHash)
+  dht1._addPeer({ host: common.randomHost(ipv6), port: 6969 }, targetInfoHash)
 
   dht1.listen(function () {
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: dht1.address().port
     }, {
       q: 'get_peers',
@@ -160,10 +160,10 @@ test('`get_peers` query to node with peers in table', function (t) {
   })
 })
 
-test('`announce_peer` query with bad token', function (t) {
+common.wrapTest(test, '`announce_peer` query with bad token', function (t, ipv6) {
   t.plan(2)
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
@@ -173,7 +173,7 @@ test('`announce_peer` query with bad token', function (t) {
   dht1.listen(function () {
     var token = Buffer.from('bad token')
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: dht1.address().port
     }, {
       q: 'announce_peer',
@@ -192,11 +192,11 @@ test('`announce_peer` query with bad token', function (t) {
   })
 })
 
-test('`announce_peer` query gets ack response', function (t) {
+common.wrapTest(test, '`announce_peer` query gets ack response', function (t, ipv6) {
   t.plan(5)
 
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   common.failOnWarningOrError(t, dht1)
   common.failOnWarningOrError(t, dht2)
@@ -206,7 +206,7 @@ test('`announce_peer` query gets ack response', function (t) {
   dht1.listen(function () {
     var port = dht1.address().port
     dht2._rpc.query({
-      host: '127.0.0.1',
+      host: common.localHost(ipv6, true),
       port: port
     }, {
       q: 'get_peers',
@@ -220,7 +220,7 @@ test('`announce_peer` query gets ack response', function (t) {
       t.ok(Buffer.isBuffer(res1.r.token))
 
       dht2._rpc.query({
-        host: '127.0.0.1',
+        host: common.localHost(ipv6, true),
         port: port
       }, {
         q: 'announce_peer',
@@ -239,3 +239,13 @@ test('`announce_peer` query gets ack response', function (t) {
     })
   })
 })
+
+function getNodes (res, ipv6) {
+  return ipv6 ? res.r.nodes6 : res.r.nodes
+}
+
+function getNodeLength (ipv6) {
+  // 20 byte node id + 2 byte port (22 bytes total)
+  // 16-byte IPv6 address, or 4-byte IPv4 address
+  return 22 + (ipv6 ? 16 : 4)
+}

--- a/test/live/lookup.js
+++ b/test/live/lookup.js
@@ -1,13 +1,19 @@
 var DHT = require('../../')
 var test = require('tape')
+var common = require('../common')
 
 var pride = '1E69917FBAA2C767BCA463A96B5572785C6D8A12'.toLowerCase() // Pride & Prejudice
 var leaves = 'D2474E86C95B19B8BCFDB92BC12C9D44667CFA36'.toLowerCase() // Leaves of Grass
 
-test('Default bootstrap server returns at least one node', function (t) {
+// Ubuntu torrents from http://torrent.ubuntu.com:6969/
+
+var ubuntuDesktop = '0403fb4728bd788fbcb67e87d6feb241ef38c75a' // ubuntu-16.10-desktop-amd64.iso
+var ubuntuServer = 'bf6f2be549a8aca5776638b59b2bca53d7bbc748' // ubuntu-16.10-server-amd64.iso
+
+common.wrapTest(test, 'Default bootstrap server returns at least one node', function (t, ipv6) {
   t.plan(1)
 
-  var dht = new DHT()
+  var dht = new DHT({ipv6: ipv6})
 
   dht.once('node', function (node) {
     t.pass('Found at least one other DHT node')
@@ -15,10 +21,11 @@ test('Default bootstrap server returns at least one node', function (t) {
   })
 })
 
-test('Default bootstrap server returns a peer for one torrent', function (t) {
+common.wrapTest(test, 'Default bootstrap server returns a peer for one torrent', function (t, ipv6) {
   t.plan(4)
 
-  var dht = new DHT()
+  var dht = new DHT({ipv6: ipv6})
+  var torrent = ipv6 ? ubuntuDesktop : pride
 
   dht.once('node', function (node) {
     t.pass('Found at least one other DHT node')
@@ -27,49 +34,52 @@ test('Default bootstrap server returns a peer for one torrent', function (t) {
   dht.on('ready', function () {
     t.pass('dht ready')
 
-    dht.lookup(pride)
+    dht.lookup(torrent)
 
     dht.once('peer', function (peer, infoHash) {
       t.pass('Found at least one peer that has the file')
-      t.equal(infoHash.toString('hex'), pride)
+      t.equal(infoHash.toString('hex'), torrent)
       dht.destroy()
     })
   })
 })
 
-test('Default bootstrap server returns a peer for two torrents (simultaneously)', function (t) {
+common.wrapTest(test, 'Default bootstrap server returns a peer for two torrents (simultaneously)', function (t, ipv6) {
   t.plan(3)
 
-  var dht = new DHT()
+  var dht = new DHT({ipv6: ipv6})
 
   dht.on('ready', function () {
     t.pass('dht ready')
 
-    dht.lookup(pride)
-    dht.lookup(leaves)
+    var torrent1 = ipv6 ? ubuntuDesktop : pride
+    var torrent2 = ipv6 ? ubuntuServer : leaves
 
-    var prideDone = false
-    var leavesDone = false
+    dht.lookup(torrent1)
+    dht.lookup(torrent2)
+
+    var torrent1Done = false
+    var torrent2Done = false
     dht.on('peer', function (peer, infoHash) {
-      if (!prideDone && infoHash.toString('hex') === pride) {
-        prideDone = true
-        t.pass('Found at least one peer for Pride & Prejudice')
+      if (!torrent1Done && infoHash.toString('hex') === torrent1) {
+        torrent1Done = true
+        t.pass('Found at least one peer for ' + (ipv6 ? 'Ubuntu Desktop' : 'Pride & Prejudice'))
       }
-      if (!leavesDone && infoHash.toString('hex') === leaves) {
-        leavesDone = true
-        t.pass('Found at least one peer for Leaves of Grass')
+      if (!torrent2Done && infoHash.toString('hex') === torrent2) {
+        torrent2Done = true
+        t.pass('Found at least one peer for ' + (ipv6 ? 'Ubuntu Server' : 'Leaves of Grass'))
       }
-      if (leavesDone && prideDone) {
+      if (torrent2Done && torrent1Done) {
         dht.destroy()
       }
     })
   })
 })
 
-test.only('Find peers before ready is emitted', function (t) {
+common.wrapTest(test.only, 'Find peers before ready is emitted', function (t, ipv6) {
   t.plan(3)
-
-  var dht = new DHT()
+  2
+  var dht = new DHT({ipv6: ipv6})
   var then = Date.now()
 
   dht.once('node', function (node) {
@@ -78,9 +88,9 @@ test.only('Find peers before ready is emitted', function (t) {
 
   dht.once('peer', function (peer, infoHash) {
     t.pass('Found at least one peer that has the file')
-    t.equal(infoHash.toString('hex'), pride, 'Found a peer in ' + (Date.now() - then) + ' ms')
+    t.equal(infoHash.toString('hex'), ipv6 ? ubuntuDesktop : pride, 'Found a peer in ' + (Date.now() - then) + ' ms')
     dht.destroy()
   })
 
-  dht.lookup(pride)
+  dht.lookup(ipv6 ? ubuntuDesktop : pride)
 })

--- a/test/to-json.js
+++ b/test/to-json.js
@@ -3,10 +3,10 @@ var DHT = require('../')
 var ed = require('ed25519-supercop')
 var test = require('tape')
 
-test('dht.toJSON: re-use dht nodes with `bootstrap` option', function (t) {
+common.wrapTest(test, 'dht.toJSON: re-use dht nodes with `bootstrap` option', function (t, ipv6) {
   t.plan(1)
 
-  var dht1 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht1)
 
   common.addRandomNodes(dht1, DHT.K)
@@ -22,10 +22,10 @@ test('dht.toJSON: re-use dht nodes with `bootstrap` option', function (t) {
   })
 })
 
-test('dht.toJSON: re-use dht nodes by calling dht.addNode', function (t) {
+common.wrapTest(test, 'dht.toJSON: re-use dht nodes by calling dht.addNode', function (t, ipv6) {
   t.plan(1)
 
-  var dht1 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
   common.failOnWarningOrError(t, dht1)
 
   common.addRandomNodes(dht1, DHT.K)
@@ -45,11 +45,11 @@ test('dht.toJSON: re-use dht nodes by calling dht.addNode', function (t) {
   })
 })
 
-test('dht.toJSON: BEP44 immutable value', function (t) {
+common.wrapTest(test, 'dht.toJSON: BEP44 immutable value', function (t, ipv6) {
   t.plan(10)
 
-  var dht1 = new DHT({ bootstrap: false })
-  var dht2 = new DHT({ bootstrap: false })
+  var dht1 = new DHT({ bootstrap: false, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, ipv6: ipv6 })
 
   t.once('end', function () {
     dht1.destroy()
@@ -59,7 +59,7 @@ test('dht.toJSON: BEP44 immutable value', function (t) {
   common.failOnWarningOrError(t, dht2)
 
   dht1.listen(function () {
-    dht2.addNode({ host: '127.0.0.1', port: dht1.address().port })
+    dht2.addNode({ host: common.localHost(ipv6, true), port: dht1.address().port })
     dht2.once('node', ready)
   })
 
@@ -83,12 +83,12 @@ test('dht.toJSON: BEP44 immutable value', function (t) {
   }
 })
 
-test('dht.toJSON: BEP44 mutable value', function (t) {
+common.wrapTest(test, 'dht.toJSON: BEP44 mutable value', function (t, ipv6) {
   t.plan(10)
 
   var keypair = ed.createKeyPair(ed.createSeed())
-  var dht1 = new DHT({ bootstrap: false, verify: ed.verify })
-  var dht2 = new DHT({ bootstrap: false, verify: ed.verify })
+  var dht1 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
+  var dht2 = new DHT({ bootstrap: false, verify: ed.verify, ipv6: ipv6 })
 
   t.once('end', function () {
     dht1.destroy()
@@ -98,7 +98,7 @@ test('dht.toJSON: BEP44 mutable value', function (t) {
   common.failOnWarningOrError(t, dht2)
 
   dht1.listen(function () {
-    dht2.addNode({ host: '127.0.0.1', port: dht1.address().port })
+    dht2.addNode({ host: common.localHost(ipv6, true), port: dht1.address().port })
     dht2.once('node', ready)
   })
 


### PR DESCRIPTION
[k-rpc-socket](https://github.com/mafintosh/k-rpc-socket/pull/6) | [k-rpc](https://github.com/mafintosh/k-rpc/pull/5) | bittorrent-dht | [torrent-discovery](https://github.com/feross/torrent-discovery/pull/27) | [webtorrent](https://github.com/feross/webtorrent/pull/950)

This is one of many pull requests across the WebTorrent ecosystem to add IPv6 DHT support, as per https://github.com/feross/bittorrent-dht/issues/88

Per [the BEP 32 statement about maintaining distinct IPv4/IPv6 DHTs](http://www.bittorrent.org/beps/bep_0032.html#operation) and the discussion on https://github.com/feross/bittorrent-dht/issues/88, my implementation requires separate instances of `bittorrent-dht` and everything below it on the protocol stack (`k-rpc` and `k-rpc-socket`). `torrent-discovery` maintains up to two `DHT` instances, one for each IP version used. Fortunately, WebTorrent already supports IPv6 peers, so no changes are needed in it beyond properly using the IPv6 DHT, if enabled in the options.

The best way to run all of my changes is by using the [npm link](https://docs.npmjs.com/cli/link) command. Assuming that all of the necessary modules (`k-rpc-socket`, `k-rpc`, `bittorrent-dht`, `torrent-discovery`, `webtorrent`, and `webtorrent-cli` are sibling directories, the following commands will set things up properly (starting from the parent directory):

```
cd k-rpc-socket
npm install
npm link
cd ../k-rpc
npm install
npm link k-rpc-socket
npm link
cd ../bittorrent-dht
npm install
npm link k-rpc
npm link
cd ../torrent-discovery
npm install
npm link bittorrent-dht
npm link
cd ../webtorrent
npm install
npm link bittorrent-dht
npm link torrent-discovery
npm link
cd ../webtorrent-cli
npm install
npm link webtorrent
```

From there, you can test and run individual modules as you choose.

---

**bittorrent-dht** specific notes:

This repository has comparatively few changes - most of them are just wrapping the tests to use both `IPv4` and `IPv6` DHTs. I make use of the `_encodeIP` function that I add in `k-rpc` to write out the encoded form of an IPv4 or IPv6 address.

Notes:
- My implementation can parse [hybrid `values` lists](http://www.bittorrent.org/beps/bep_0032.html#values). i.e. ones which contain a mixture of `IPv4` and `IPv6` addresses. However, I treat them as a non-fatal error condition, since they aren't supposed to be sent.
- For the live test, I use `ubuntu-16.10-desktop-amd64.iso` and `ubuntu-16.10-server-amd64.iso`, since the other torrents don't have any IPv6 DHT nodes available. As Ubuntu is a fairly popular Linux distribution, there should always be at least some nodes in the DHT serving it.
