### PR TITLE
don't cache mutable value since it could be changed by other peers.

### DIFF
--- a/client.js
+++ b/client.js
@@ -273,9 +273,6 @@ DHT.prototype.put = function (opts, cb) {
   if (isMutable && opts.cas !== undefined && typeof opts.cas !== 'number') {
     throw new Error('opts.cas must be an integer if provided')
   }
-  if (isMutable && !opts.k) {
-    throw new Error('opts.k ed25519 public key required for mutable put')
-  }
   if (isMutable && opts.k.length !== 32) {
     throw new Error('opts.k ed25519 public key must be 32 bytes')
   }

--- a/client.js
+++ b/client.js
@@ -323,9 +323,10 @@ DHT.prototype._put = function (opts, cb) {
     message.a.seq = opts.seq
     if (typeof opts.sign === 'function') message.a.sig = opts.sign(encodeSigData(message.a))
     else if (Buffer.isBuffer(opts.sig)) message.a.sig = opts.sig
+  } else {
+    this._values.set(key.toString('hex'), message.a)
   }
 
-  this._values.set(key.toString('hex'), message.a)
   this._rpc.queryAll(table.closest(key), message, null, function (err, n) {
     if (err) return cb(err, key, n)
     cb(null, key, n)

--- a/test/dht_store_mutable.js
+++ b/test/dht_store_mutable.js
@@ -16,7 +16,12 @@ test('local mutable put/get', function (t) {
   })
   common.failOnWarningOrError(t, dht)
 
-  dht.on('ready', function () {
+  dht.listen(function () {
+    dht.addNode({ host: '127.0.0.1', port: dht.address().port })
+    dht.once('node', ready)
+  })
+
+  function ready () {
     var value = common.fill(500, 'abc')
     var opts = {
       k: keypair.publicKey,
@@ -41,7 +46,7 @@ test('local mutable put/get', function (t) {
         t.equal(res.seq, 0)
       })
     })
-  })
+  }
 })
 
 test('multiparty mutable put/get', function (t) {

--- a/test/dht_test_vectors.js
+++ b/test/dht_test_vectors.js
@@ -26,7 +26,12 @@ test('dht store test vectors', function (t) {
   })
   common.failOnWarningOrError(t, dht)
 
-  dht.on('ready', function () {
+  dht.listen(function () {
+    dht.addNode({ host: '127.0.0.1', port: dht.address().port })
+    dht.once('node', ready)
+  })
+
+  function ready () {
     var opts = {
       k: pub,
       seq: 1,
@@ -60,5 +65,5 @@ test('dht store test vectors', function (t) {
         t.equal(res.seq, 1)
       })
     })
-  })
+  }
 })

--- a/test/to-json.js
+++ b/test/to-json.js
@@ -84,7 +84,7 @@ test('dht.toJSON: BEP44 immutable value', function (t) {
 })
 
 test('dht.toJSON: BEP44 mutable value', function (t) {
-  t.plan(10)
+  t.plan(5)
 
   var keypair = ed.createKeyPair(ed.createSeed())
   var dht1 = new DHT({ bootstrap: false, verify: ed.verify })
@@ -112,13 +112,6 @@ test('dht.toJSON: BEP44 mutable value', function (t) {
     }
 
     dht1.put(opts, function (_, hash) {
-      var json1 = dht1.toJSON()
-      t.equal(json1.values[hash.toString('hex')].v, value.toString('hex'))
-      t.equal(json1.values[hash.toString('hex')].id, dht1.nodeId.toString('hex'))
-      t.equal(json1.values[hash.toString('hex')].seq, 0)
-      t.equal(typeof json1.values[hash.toString('hex')].sig, 'string')
-      t.equal(typeof json1.values[hash.toString('hex')].k, 'string')
-
       var json2 = dht2.toJSON()
       t.equal(json2.values[hash.toString('hex')].v, value.toString('hex'))
       t.equal(json2.values[hash.toString('hex')].id, dht1.nodeId.toString('hex'))


### PR DESCRIPTION
I'm testing DHT put with mutable value. The obvious problem is, we cached the value for mutable items, which means even it gets changed by other peers, we can't get the new value with current DHT instance.


