### PR TITLE
Allow specifying custom implementation of k-rpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,11 +74,12 @@ If `opts` is specified, then the default options (shown below) will be overridde
 
 ``` js
 {
-  nodeId: '',     // 160-bit DHT node ID (Buffer or hex string, default: randomly generated)
-  bootstrap: [],  // bootstrap servers (default: router.bittorrent.com:6881, router.utorrent.com:6881, dht.transmissionbt.com:6881)
-  host: false,    // host of local peer, if specified then announces get added to local table (String, disabled by default)
-  concurrency: 16 // k-rpc option to specify maximum concurrent UDP requests allowed (Number, 16 by default)
-  hash: Function  // custom hash function to use (Function, SHA1 by default)
+  nodeId: '',      // 160-bit DHT node ID (Buffer or hex string, default: randomly generated)
+  bootstrap: [],   // bootstrap servers (default: router.bittorrent.com:6881, router.utorrent.com:6881, dht.transmissionbt.com:6881)
+  host: false,     // host of local peer, if specified then announces get added to local table (String, disabled by default)
+  concurrency: 16, // k-rpc option to specify maximum concurrent UDP requests allowed (Number, 16 by default)
+  hash: Function,  // custom hash function to use (Function, SHA1 by default),
+  krpc: krpc()     // optional k-rpc instance
 }
 ```
 

--- a/client.js
+++ b/client.js
@@ -26,7 +26,7 @@ function DHT (opts) {
   this._peers = new PeerStore(opts.maxPeers || 10000)
 
   this._secrets = null
-  this._rpc = krpc(opts)
+  this._rpc = opts.krpc || krpc(opts)
   this._rpc.on('query', onquery)
   this._rpc.on('node', onnode)
   this._rpc.on('warning', onwarning)


### PR DESCRIPTION
I'm working on https://github.com/webtorrent/webtorrent/issues/288 and similarly to https://github.com/mafintosh/k-rpc/pull/8 I need to be able to provide a custom implementation of k-rpc.