### PR TITLE
Use `jssha` and `randombytes` packages in order to avoid large overhead of `crypto` in browserify build

### DIFF
--- a/client.js
+++ b/client.js
@@ -587,7 +587,7 @@ DHT.prototype._validateToken = function (host, token) {
 
 DHT.prototype._generateToken = function (host, secret) {
   if (!secret) secret = this._secrets[0]
-  return sha1(Buffer.concat([Buffer.from(host), secret]))
+  return this._hash(Buffer.concat([Buffer.from(host), secret]))
 }
 
 DHT.prototype._rotateSecrets = function () {

--- a/client.js
+++ b/client.js
@@ -6,11 +6,11 @@ var debug = require('debug')('bittorrent-dht')
 var equals = require('buffer-equals')
 var EventEmitter = require('events').EventEmitter
 var inherits = require('inherits')
-var JSSHA = require('jssha/src/sha1')
 var KBucket = require('k-bucket')
 var krpc = require('k-rpc')
 var LRU = require('lru')
 var randombytes = require('randombytes')
+var simpleSha1 = require('simple-sha1')
 
 var ROTATE_INTERVAL = 5 * 60 * 1000 // rotate secrets every 5 minutes
 
@@ -602,9 +602,7 @@ DHT.prototype._rotateSecrets = function () {
 function noop () {}
 
 function sha1 (buf) {
-  var shaObj = new JSSHA('SHA-1', 'ARRAYBUFFER')
-  shaObj.update(buf)
-  return Buffer.from(shaObj.getHash('ARRAYBUFFER'))
+  return Buffer.from(simpleSha1.sync(buf), 'hex')
 }
 
 function createGetResponse (id, token, value) {

--- a/package.json
+++ b/package.json
@@ -15,9 +15,11 @@
     "buffer-equals": "^1.0.3",
     "debug": "^2.2.0",
     "inherits": "^2.0.1",
+    "jssha": "^2.3.1",
     "k-bucket": "^3.0.1",
     "k-rpc": "^4.0.0",
     "lru": "^3.1.0",
+    "randombytes": "^2.0.5",
     "safe-buffer": "^5.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,12 @@
     "buffer-equals": "^1.0.3",
     "debug": "^2.2.0",
     "inherits": "^2.0.1",
-    "jssha": "^2.3.1",
     "k-bucket": "^3.0.1",
     "k-rpc": "^4.0.0",
     "lru": "^3.1.0",
     "randombytes": "^2.0.5",
-    "safe-buffer": "^5.0.1"
+    "safe-buffer": "^5.0.1",
+    "simple-sha1": "^2.1.0"
   },
   "devDependencies": {
     "ed25519-supercop": "^1.0.0",


### PR DESCRIPTION
Depends on https://github.com/mafintosh/k-rpc/pull/9
Fixes #164

Before: 689 kB
After: 163 kB