### PR TITLE
Fix non-compliance with BEP44 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,13 +298,19 @@ dht.get(key, function (err, res) {
 })
 ```
 
-#### `dht.get(hash, callback)`
+#### `dht.get(hash, opts, callback)`
 
 Read a data record (created with `.put()`) from the DHT.
 ([BEP 44](http://bittorrent.org/beps/bep_0044.html))
 
 Given `hash`, a hex string or buffer, lookup data content from the DHT, sending the
 result in `callback(err, res)`.
+
+These options are available:
+
+* `opts.salt` - the salt (if any) that was used during the `put()` request.
+* `opts.verify` - override the default ed25519 verification function supplied during DHT instantiation.
+* `opts.nocache` - always perform DHT lookup rather than using locally cached value.
 
 `res` objects are similar to the options objects written to the DHT with
 `.put()`:
@@ -314,7 +320,8 @@ result in `callback(err, res)`.
 * `res.k` - the public key (only present for mutable data)
 * `res.sig` - the signature (only present for mutable data)
 * `res.seq` - the sequence (optional, only present for mutable data)
-* `res.salt` - the salt (optional, only present for mutable data)
+
+Note that `res.salt` will not be returned by BEP44 compliant nodes, but this value should be known as it is required to compute the `hash`.
 
 ### events
 

--- a/client.js
+++ b/client.js
@@ -610,7 +610,6 @@ function createGetResponse (id, token, value) {
   if (value.sig) {
     r.sig = value.sig
     r.k = value.k
-    if (value.salt) r.salt = value.salt
     if (typeof value.seq === 'number') r.seq = value.seq
   }
   return r

--- a/client.js
+++ b/client.js
@@ -232,7 +232,7 @@ DHT.prototype.get = function (key, opts, cb) {
   var hash = this._hash
   var value = this._values.get(key.toString('hex')) || null
 
-  if (value) {
+  if (value && !opts.nocache) {
     value = createGetResponse(this._rpc.id, null, value)
     return process.nextTick(done)
   }

--- a/client.js
+++ b/client.js
@@ -253,6 +253,7 @@ DHT.prototype.get = function (key, opts, cb) {
   function onreply (message) {
     var r = message.r
     if (!r || !r.v) return true
+    if (!r.salt && opts.salt) r.salt = Buffer(opts.salt)
 
     var isMutable = r.k || r.sig
 


### PR DESCRIPTION
As noted on #167 the current implementation is not compliant with the [BEP44 specification](http://www.bittorrent.org/beps/bep_0044.html), which does not stipulate that `salt` should be in the return value from a mutable `get`. This is probably because the requesting side already knows the `salt` as it is required to construct the DHT address hash.

Indeed if you test mutable `get` in the wild you observe existing Bittorrent clients on the network do not return `salt` whilst Webtorrent nodes do. This essentially means that mutable DHT `get`s with salt are currently partitioned between Webtorrent clients and other Bittorrent clients. This means that regular Bittorrent client responses will accept the `put` but then fail validation in the Webtorrent client during the `get` when they do not return `salt`. The result is that it appears mutable `put`s with salt are disappearing despite DHT nodes saying that they have successfully stored them. Only if your mutable  put happens to be stored on another Webtorrent node will you get a response that passes the ed25519 validation step.

This PR tries to fix the situation by doing the following:

 * Allow the user to pass `opts.salt` during `get` which is used during validation if remote nodes do not return a `salt` value (as per spec).
 * Stop this module from returning `salt` so that we comply with the spec. This change is not 100% required - we could continue to return `salt` even though it's not in the spec. We might not want to change this as it could break existing codebases that are not passing in `salt` and are expecting `salt` from the network (even though most nodes won't return it).
 * Updated documentation explaining how to pass `salt` (and the other undocumented options) to the `get()` request.
 * An option to defeat local DHT cached values. The reason you might want this mentioned on #155 - if remote DHT notes have a more recent version of a mutable `put` you might want to ignore the locally cached version and defer to the network.

Let me know if you want me to make any changes to this PR - happy to do so.