### PR TITLE
No need to assign `this._hash` twice

### DIFF
--- a/client.js
+++ b/client.js
@@ -40,7 +40,6 @@ function DHT (opts) {
   this._verify = opts.verify || null
   this._host = opts.host || null
   this._interval = setInterval(rotateSecrets, ROTATE_INTERVAL)
-  this._hash = opts.hash || sha1
   this._bucketCheckInterval = null
   this._bucketOutdatedTimeSpan = opts.timeBucketOutdated || BUCKET_OUTDATED_TIMESPAN
 


### PR DESCRIPTION
Introduced in 20f52073205b036e44427c8f99c4dcb8bb015ca5, feels like as the result of rebase.
Property is already assigned few lines above.