### PR TITLE
Add support for ArrayBufferView (like Uint8Array) in toBuffer() function

### DIFF
--- a/client.js
+++ b/client.js
@@ -798,6 +798,7 @@ function toNode (node) {
 
 function toBuffer (str) {
   if (Buffer.isBuffer(str)) return str
+  if (ArrayBuffer.isView(str)) return Buffer.from(str.buffer, str.byteOffset, str.byteLength)
   if (typeof str === 'string') return Buffer.from(str, 'hex')
   throw new Error('Pass a buffer or a string')
 }


### PR DESCRIPTION
This makes my life a bit simpler when interacting with `bittorrent-dht` since `Uint8Array` is supported in browser natively and `Buffer` is not.

Complements https://github.com/mafintosh/k-rpc/pull/15

https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView