### PR TITLE
Allow signing mutable data asynchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ For mutable content, the hash will be the hash of the public key, `opts.k`.
 These options are available:
 
 * `opts.k` - ed25519 public key buffer (32 bytes) (REQUIRED)
-* `opts.sign(buf)` - function to generate an ed25519 signature buffer (64 bytes) corresponding to the `opts.k` public key (REQUIRED)
+* `opts.sign(buf[, cb])` - function to generate an ed25519 signature buffer (64 bytes) corresponding to the `opts.k` public key (REQUIRED)
 * `opts.seq` - optional sequence (integer), must monotonically increase (REQUIRED)
 * `opts.cas` - optional previous sequence for compare-and-swap
 * `opts.salt` - optional salt buffer to include (<= 64 bytes) when calculating
@@ -263,8 +263,8 @@ const opts = {
   k: keypair.pk,
   seq: 0,
   v: value,
-  sign: function (buf) {
-    return ed.sign(buf, keypair.sk)
+  sign: function (buf, cb) {
+    cb(ed.sign(buf, keypair.sk))
   }
 }
 


### PR DESCRIPTION
This can be useful if we want to keep the private key out of the process.

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix
[X] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

If the `sign` field in `opts` has two arguments, assume the second one is for an asynchronous callback.

Restructure the code to accommodate this.

**Which issue (if any) does this pull request address?**

None.

**Is there anything you'd like reviewers to focus on?**

Maybe there is too much green for such a small addition.