### PR TITLE
give access to encodeSigData

### DIFF
--- a/client.js
+++ b/client.js
@@ -58,6 +58,8 @@ class DHT extends EventEmitter {
 
     this._debug('new DHT %s', this.nodeId)
 
+    this.encodeSigData = encodeSigData
+
     const self = this
 
     function ping (opts, cb) {


### PR DESCRIPTION
[ ] Documentation update
[ ] Bug fix
[ ] New feature
[X ] Other, please explain:

**What changes did you make? (Give an overview)**
only added one line, this.encodeSigData = encodeSigData

**Which issue (if any) does this pull request address?**
it gives people who are using bittorrent-dht access to the encodeSigData function that way they can use it on their verify function to save their sig before using dht.put()

**Is there anything you'd like reviewers to focus on?**
If this is not mergable, then that is fine. i am working on a bep 46 management module [webproperty](https://github.com/webproperty/webproperty) so it would be easier for me to use `let sig = verify(dht.encodeSigData(someData), secretkey)` that way i can save the sig and keep putting it back into the dht to keep the data active. but if you can not merge it, then i can use `bencode.encode({seq, v}).slice(1, -1)` instead. why i would like to add this is because if the encodeSigData function is ever changed, then we can still access it with `this.encodeSigData()`.